### PR TITLE
Fix the implicit generic definition and undefined function warnings.

### DIFF
--- a/dev/macros.lisp
+++ b/dev/macros.lisp
@@ -74,11 +74,11 @@ instead
 		`(defmethod binding-form-accepts-multiple-forms-p 
 		      ((binding-form (eql ,name)))
 		    ,accept-multiple-forms-p))
-	 (defmethod ,main-method-name 
-	     (,@(unless multiple-names?
-			(if force-keyword?
-			    `((kind (eql ,name/s)))
-			    `((kind ,name/s))))
+	 (,(if multiple-names? 'defun 'defmethod) ,main-method-name
+           (,@(unless multiple-names?
+                      (if force-keyword?
+                          `((kind (eql ,name/s)))
+                          `((kind ,name/s))))
 	      variable-form value-form body declarations remaining-bindings)
 	   ,(if use-values-p
 		;; surely this could be simpler!


### PR DESCRIPTION
There is no point in using a generic for the multiple-names core
function, because there is only one method initially, and no way
to add more due to the name being a gensym. A defun is sufficient,
and has none of the warning problems.
