### PR TITLE
fix GNU CLISP own bug.

### DIFF
--- a/dev/macros.lisp
+++ b/dev/macros.lisp
@@ -74,7 +74,7 @@ form.)
 	 #+(or)
 	 (gignores (gensym "ignores")))    
     (cond (multiple-names?
-	   (setf main-method-name (gensym (symbol-name '#:binding-generator)))
+	   (setf main-method-name (gentemp (symbol-name '#:binding-generator)))
 	   )
 	  (t
 	   (setf main-method-name 'bind-generate-bindings)


### PR DESCRIPTION
Probably CLISP lose uninterned symbol's value after LOAD.
So change GENSYM to GENTEMP.

CLISP's error message is below. 

;; Dribble of #<IO TERMINAL-STREAM> started on NIL.
# <OUTPUT BUFFERED FILE-STREAM CHARACTER #P"test">

[2]> (ql:quickload :metabang-bind)
To load "metabang-bind":
  Load 1 ASDF system:
    metabang-bind
; Loading "metabang-bind"

(:METABANG-BIND)
[3]> (bind:bind(((:plist a b)'(:a 1 :b 2)))(list a b))

**\* - FUNCALL: undefined function #:BINDING-GENERATOR31636
The following restarts are available:
USE-VALUE      :R1      Input a value to be used instead of (FDEFINITION '#:BINDING-GENERATOR31636).
RETRY          :R2      Retry
STORE-VALUE    :R3      Input a new value for (FDEFINITION '#:BINDING-GENERATOR31636).
ABORT          :R4      Abort main loop

Break 1 [4]> (dribble)
2014-10-01 11:18:15
;; Dribble of #<IO TERMINAL-STREAM> finished on NIL.
