### PR TITLE
add binding-form for file. Works as WITH-OPEN-FILE.

### DIFF
--- a/dev/binding-forms.lisp
+++ b/dev/binding-forms.lisp
@@ -452,3 +452,7 @@ keywords as keys. For example:
 #+(or)
 (bind (((:plist- a (b _) (c _ 2) (dd d)) '(b "B" a "A" d "D")))
   (list a b c dd))
+
+(defbinding-form (:file :use-values-p nil
+			:accept-multiple-forms-p t)
+  `(with-open-file ,(append variables  (car values))))


### PR DESCRIPTION
I think it is making new context that the concept behind metabang-bind.
If so WITH-OPEN-FILE should be integrated in bind.

how to use

(bind:bind(((:file stream)("test" :direction :output 
                                                :if-exists :supersede)))
  (print "something" stream))
