### PR TITLE
Use LET instead of PROGN in expansion of DEFBINDING-FORM

### DIFF
--- a/dev/macros.lisp
+++ b/dev/macros.lisp
@@ -83,7 +83,7 @@ form.)
 	(setf name/s (if multiple-names? 
 			 (mapcar #'form-keyword name/s)
 			 (form-keyword name/s))))
-      `(progn
+      `(let ()
 	 (setf (binding-form-docstring ',name/s) ,docstring)
 	 ,@(loop for name in (if multiple-names? name/s (list name/s)) 
 	       when (keywordp name) collect


### PR DESCRIPTION
This workaround is required due to a long standing bug in CLISP: https://sourceforge.net/p/clisp/bugs/180/

Also fixes https://github.com/gwkkwg/metabang-bind/issues/11

I ran the unit tests on SBCL, CCL, CMUCL and CLISP. Apart from 4 failures which were occurring even before I made this change, all the tests pass.