### PR TITLE
Use INTERN instead of READ-FROM-STRING to create keyword

### DIFF
--- a/dev/binding-forms.lisp
+++ b/dev/binding-forms.lisp
@@ -496,8 +496,7 @@ keywords as keys. For example:
 		 (when (string= (symbol-name var-key) "_")
 		   (setf var-key var-name))
 		 (when form-keywords?
-		   (setf var-key (let ((*package* (find-package :keyword)) *read-eval*)
-				   (read-from-string (symbol-name var-key)))))
+		   (setf var-key (intern (symbol-name var-key) (find-package :keyword))))
 		 `(,var-name (getf ,values
 				   ,(if form-keywords?
 					var-key `',var-key)


### PR DESCRIPTION
This is simpler and fixes a bug when the value of `readtable-case` is `:preserve` or `:invert`.