### PR TITLE
defbinding-form supports accept-multiple-forms-p when name is a type

### DIFF
--- a/dev/bind.lisp
+++ b/dev/bind.lisp
@@ -195,7 +195,8 @@ of arguments and then the function body (in an implicit progn)."
 				     (first variable-form))))
 	(when (and (consp value-form) 
 		   (cdr value-form)
-		   (or (null binding-form)
+		   (if (null binding-form)
+                       (not (binding-form-accepts-multiple-forms-p variable-form))
 		       (not (binding-form-accepts-multiple-forms-p binding-form))))
 	  (error 'bind-too-many-value-forms-error 
 		:variable-form variable-form :value-form value-form))

--- a/dev/macros.lisp
+++ b/dev/macros.lisp
@@ -64,6 +64,10 @@ This binding form tells to expand clauses whose first element is
 a symbol using `let`. (It also gets `bind` to signal an error if
 the first element is a keyword that doesn't have a defined binding
 form.)
+
+If `use-values-p` is T, first bind value forms to gensyms to ensure
+they are evaluated only once. If `accept-multiple-forms-p` is T, allow
+passing multiple value forms, otherwise doing so results in an error.
 "
   (declare (ignorable remove-nils-p description))
   (let* ((multiple-names? (consp name/s))
@@ -86,9 +90,9 @@ form.)
       `(let ()
 	 (setf (binding-form-docstring ',name/s) ,docstring)
 	 ,@(loop for name in (if multiple-names? name/s (list name/s)) 
-	       when (keywordp name) collect
-		`(defmethod binding-form-accepts-multiple-forms-p 
-		      ((binding-form (eql ,name)))
+	         collect
+		 `(defmethod binding-form-accepts-multiple-forms-p
+		      ((binding-form ,(if (keywordp name) `(eql ,name) name)))
 		    ,accept-multiple-forms-p))
 	 (,(if multiple-names? 'defun 'defmethod) ,main-method-name
            (,@(unless multiple-names?


### PR DESCRIPTION
Previously, `defbinding-form` silently ignores `:accept-multiple-forms-p` when  name is a type instead of a keyword, and passing multiple forms still results in an error. This patch makes its behavior consistent with the keyword case.

I also added some clarification to `defbinding-form`'s docstring. Hope I understand it correctly by reading the source, please correct me if it's not accurate!
